### PR TITLE
Makefile,scripts: Support running the timbot container in the fg or bg.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,18 @@
+SHELL := /bin/bash
+
 ROOT_DIR:= $(patsubst %/,%,$(dir $(realpath $(lastword $(MAKEFILE_LIST)))))
 
-CONTAINER_BUILD_CMD = podman build
+CONTAINER_BUILD_CMD := podman build
+CONTAINER_RUN_IN_BG := true
 
 build-timbot:
 	$(CONTAINER_BUILD_CMD) -f Dockerfile -t timbot $(ROOT_DIR)
 
 run-timbot:
 	$(ROOT_DIR)/scripts/run-timbot-local.sh
+
+run-timbot-bg:
+	export CONTAINER_RUN_IN_BG = true
+
+run-timbot-bg:
+	$(MAKE) run-timbot

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 A Slack "bot" to replace our dear friend Tim
 
 ## Usage
-### Normal Run 
+### Normal Run
 TODO
 
 ### Local Run
@@ -25,6 +25,13 @@ $ make build-timbot
 ```
 
 ##### Running the timbot image locally
+**Note**: Before running the following, ensure that the following environment variables are appropriately set:
+- `$SLACK_API_TOKEN`: the legacy api slack token granted to your slack account.
+- `$SLACK_CHANNEL_ID`: the channel ID number.
+- `$SLACK_TIMBOT_USER_ID`: the timbot slack user ID.
+
+Once those variables are set, run the following to run the timbot client in the foreground:
+
 ```bash
 $ make run-timbot
 ```
@@ -34,4 +41,4 @@ $ make run-timbot
 ## References
 - https://api.slack.com/custom-integrations/legacy-tokens
 - https://slack.dev/python-slackclient/
-- https://api.slack.com/methods 
+- https://api.slack.com/methods

--- a/scripts/run-timbot-local.sh
+++ b/scripts/run-timbot-local.sh
@@ -14,14 +14,15 @@ elif [[ -z "$SLACK_TIMBOT_USER_ID" ]]; then
 fi
 
 CONTAINER_RUN_CMD=${CONTAINER_RUN_CMD:-"podman run"}
+CONTAINER_RUN_IN_BG=${CONTAINER_RUN_IN_BG:="false"}
 
 set -x
 
 ${CONTAINER_RUN_CMD} \
     --name timbot-local \
     --rm \
-    -d \
-    -e SLACK_API_TOKEN="$SLACK_API_TOKEN" \
-    -e SLACK_CHANNEL_NAME="$SLACK_CHANNEL_NAME" \
-    -e SLACK_TIMBOT_USER_ID="$SLACK_TIMBOT_USER_ID" \
+    -e SLACK_API_TOKEN="${SLACK_API_TOKEN}" \
+    -e SLACK_CHANNEL_NAME="${SLACK_CHANNEL_NAME}" \
+    -e SLACK_TIMBOT_USER_ID="${SLACK_TIMBOT_USER_ID}" \
+    -d=${CONTAINER_RUN_IN_BG} \
     -it timbot


### PR DESCRIPTION
Alternatively, could just support a `make start-timbot` and `make stop-timbot` kind of scheme, with the container always being run in the background. The default behavior can be to run the container in the background, and still support a `make run-timbot-fg` option.