### PR TITLE
Updated versions of action repos used in CI

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,6 +8,6 @@ jobs:
     name: build
     steps:
     - name: Checkout repo
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
     - name: Build container image
       run: docker build -f Dockerfile .

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -7,9 +7,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repo
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
     - name: Set up Python 2.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: 2.7
     - name: Install dependencies


### PR DESCRIPTION
We're using the `v1` version of both the `checkout` and `setup-python` actions repos but `v2` is the currently supported version for both