### PR TITLE
.github: Standup a barebones MySQL database instance.

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,11 +3,22 @@ name: docker
 on: [pull_request, push]
 
 jobs:
-  build_docker_image:
+  build:
     runs-on: ubuntu-latest
     name: build
     steps:
     - name: Checkout repo
       uses: actions/checkout@v2
-    - name: Build container image
-      run: docker build -f Dockerfile .
+    - name: Start the default mysql service
+      run: sudo systemctl start mysql.service
+    - name: Add the test schema.sql
+      run: |
+        set -ex
+
+        # remove the drop database call
+        tail -n +2 ./schema.sql > schema.tmp.sql
+        mysql -uroot -proot < ./schema.tmp.sql
+    - name: Ensure the MySQL container is healthy
+      run: mysql -uroot -proot -e "select * from timbot.users;"
+    - name: Build the timbot container image
+      run: docker build -f Dockerfile -t timbot:timbot .

--- a/scripts/run-mysql-container.sh
+++ b/scripts/run-mysql-container.sh
@@ -1,9 +1,20 @@
 #! /bin/bash
 
-CONTAINER_RUNTIME="podman"
-CONTAINER_RUN_CMD="${CONTAINER_RUNTIME} run"
+set -x
+
+ROOT_DIR=$(dirname "${BASH_SOURCE}")/..
+ABS_PATH_TIMBOT_SCHEMA=$(readlink -f ${ROOT_DIR}/schema.sql)
+
+CONTAINER_RUNTIME="${CONTAINER_RUNTIME:="podman"}"
+CONTAINER_RUN_CMD="${CONTAINER_RUN_CMD:=$CONTAINER_RUNTIME run}"
 
 echo "Pulling the mysql:8.0 container locally"
 ${CONTAINER_RUNTIME} pull mysql:8.0
 echo "Running the mysql:8.0 container locally"
-${CONTAINER_RUN_CMD} -d --network host -e MYSQL_ROOT_PASSWORD=testpass -e MYSQL_USER=testuser -e MYSQL_PASSWORD=testpass -e MYSQL_DATABASE=timbot mysql:8.0
+${CONTAINER_RUN_CMD} --name timbot-dev-ci \
+    --rm \
+    -v ${ABS_PATH_TIMBOT_SCHEMA}:/tmp/schema.sql \
+    -e MYSQL_USER=testuser \
+    -e MYSQL_ROOT_PASSWORD=testpass \
+    -e MYSQL_PASSWORD=testpass \
+    mysql:8.0

--- a/scripts/run-timbot-dev.sh
+++ b/scripts/run-timbot-dev.sh
@@ -3,9 +3,16 @@
 CONTAINER_RUN_CMD=${CONTAINER_RUN_CMD:-"docker run"}
 CONTAINER_ENV_FILE=${CONTAINER_ENV_FILE:-"dev-local-env"}
 
+CI=${CI:=false}
+
+if [[ "$CI" == "true" ]]; then
+    echo "Dumping the MYSQL_* environment variables"
+    printenv | grep MYSQL_
+fi
+
 ${CONTAINER_RUN_CMD} \
     --rm \
-    -it \
+    -i \
     --network="host" \
     -e SLACK_API_TOKEN="$SLACK_API_TOKEN" \
     -e SLACK_TIMBOT_USER_ID="$SLACK_TIMBOT_USER_ID" \


### PR DESCRIPTION
These are fairly-straightfoward changes for standing up a mysql database that contains the timbot schema.sql and ensures that schema gets loaded correctly by the default ubuntu mysql instance (5.7). Was having difficulties getting this to work with any mysql containers and there's no great way to stop the timbot container while running the github jobs, so this will have to due for now.

In the future, we could do something like this:
```yaml
...
    - name: Ensure the MySQL container is healthy
      run: mysql -uroot -proot -e "select * from timbot.users;"
    - name: Build the timbot container image
      run: docker build -f Dockerfile -t timbot:timbot .
    - name: Run timbot locally
      run: |
        ./scripts/run-timbot-dev.sh
        exit $?
      env:
        MYSQL_USER: root
        MYSQL_PASSWORD: root
        MYSQL_HOST: localhost
        CI: "true"
```