### PR TITLE
Initialize testing suite using tox/pytest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,7 @@ coverage.xml
 .hypothesis/
 .pytest_cache/
 
+src.egg-info/
+
 # timbot specific ignores
 dev-local-env

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,16 @@
+# need to get past slackclient import in pytests by making fake
+# slackclient module
+
+import sys
+
+
+class slackclient:
+
+    class SlackClient:
+        def __init__(token):
+            token = token
+
+
+module = type(sys)('slackclient')
+module.SlackClient = slackclient.SlackClient
+sys.modules['slackclient'] = module

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ mysql-connector==2.2.9
 mysql-connector-python==8.0.19
 pyyaml==5.1
 slackclient==1.3.2
+tox==3.5.3

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,5 @@
+from setuptools import setup, find_packages
+setup(
+    name="src",
+    packages=find_packages()
+)

--- a/src/database.py
+++ b/src/database.py
@@ -6,7 +6,7 @@ def get_webopoly_standings(conn):
     return standings
 
 
-def increment_weboploy_wins(conn, name):
+def increment_webopoly_wins(conn, name):
     cursor = conn.cursor()
     uid = int(cursor.execute('SELECT uid FROM users WHERE name = "{}"'.format(name)))
     wins = int(cursor.execute('SELECT wins FROM webopoly WHERE uid = {}'.format(uid)))

--- a/src/timbot.py
+++ b/src/timbot.py
@@ -5,7 +5,7 @@ import time
 import random
 import datetime
 import numpy as np
-import database as db
+from src import database as db
 import mysql.connector
 from slackclient import SlackClient
 
@@ -20,7 +20,7 @@ help_text = '''
     `where lunch no feast`: i tell you where to eat lunch that isn't epicurean feast
     `when lunch/lunch time`: i tell you when to eat lunch
     `what lunch/what eat`: i tell you what to eat
-    `increment weboploy win <name>`: more glory to whoever <name> is
+    `increment webopoly win <name>`: more glory to whoever <name> is
     `show webopoly standings`: show who is captalist king and who is poor
     `help`: this
 '''
@@ -83,7 +83,7 @@ def handle_timbot_message(message):
         uploadimage('images/lunchchart.png', 'IdealLunchTimeChart', '')
 
     # what to eat
-    elif ('what' in message) and ('eat' or 'lunch' in message):
+    elif ('what' in message) and ('eat' in message or 'lunch' in message):
         # if friday
         if datetime.datetime.today().weekday() == friday_index_elem:
             send_message('Its friday enjoy a meal out. Maybe some french toast at pauls?')
@@ -94,10 +94,10 @@ def handle_timbot_message(message):
             send_message("may I suggest the chicken sandwich")
 
     # increment weboploy win
-    elif 'increment weboploy win' in message:
+    elif 'increment webopoly win' in message:
         name = message.split()[-1]
         try:
-            db.increment_weboploy_wins(conn, name)
+            db.increment_webopoly_wins(conn, name)
         except Exception as e:
             send_message("Couldn't do it cause {}".format(e))
 
@@ -136,12 +136,12 @@ def run_timbot():
         if 'text' not in data or 'user' not in data:
             continue
 
-        sender = data['user'].encode('UTF8').lower()
-        if sender == timbot_user_id_striped:
+        sender = data['user'].encode('UTF8').lower().decode()
+        if sender == timbot_user_id_stripped:
             print('[DEBUG] last message was from the timbot_user_id, continuing to next loop iteration')
             continue
 
-        message = data['text'].encode('UTF8').lower()
+        message = data['text'].encode('UTF8').lower().decode()
 
         # openstack meme
         if 'openstack' in message:
@@ -165,7 +165,7 @@ if __name__ == '__main__':
     slack_token = os.environ['SLACK_API_TOKEN']
     channel_id = os.environ['SLACK_CHANNEL_ID']
     timbot_user_id = os.environ['SLACK_TIMBOT_USER_ID'].lower()
-    timbot_user_id_striped = timbot_user_id.strip('<@>')
+    timbot_user_id_stripped = timbot_user_id.strip('<@>')
     sc = SlackClient(slack_token)
 
     use_authenticated_user = True

--- a/tests/test_timbot.py
+++ b/tests/test_timbot.py
@@ -1,0 +1,237 @@
+import pytest
+from unittest.mock import patch
+import datetime
+from src import timbot
+
+
+class FakeSlackClient:
+    def __init__(self, fake_api_call):
+        self.fake_api_call = fake_api_call
+
+    def api_call(self, *args, **kwargs):
+        return self.fake_api_call()
+
+
+class TestTimbot:
+    def init_vars(self, cid="test-channel", uid="@timbot",
+                  uid_stripped="timbot", uae=True):
+        timbot.channel_id = cid
+        timbot.timbot_user_id = uid
+        timbot.timbot_user_id_stripped = uid_stripped
+        timbot.use_authenticated_user = uae
+
+    patch("timbot.send_message")
+
+    def test_openstack(self):
+        timbot.sc = FakeSlackClient(
+            lambda: {"messages": [{"user": "me", "text":
+                     "openstack is the best"}]})
+        self.init_vars()
+        timbot.send_message = lambda arg: (_ for _ in ()).throw(Exception(arg))
+        with pytest.raises(Exception) as e:
+            timbot.run_timbot()
+        assert str(e.value) in ["i hear openstack is a career killer"]
+
+    patch("timbot.send_message")
+
+    def test_pong(self):
+        timbot.sc = FakeSlackClient(lambda: {"messages": [{"user": "me",
+                                                           "text":
+                                             "play some pong?"}]})
+        self.init_vars()
+        timbot.send_message = lambda arg: (_ for _ in ()).throw(Exception(arg))
+        with pytest.raises(Exception) as e:
+            timbot.run_timbot()
+        assert str(e.value) in ["im in. best 2 out of 3 games to 7?"]
+
+    patch("timbot.send_message")
+
+    def test_where_lunch(self):
+        self.init_vars()
+        timbot.send_message = lambda arg: (_ for _ in ()).throw(Exception(arg))
+
+        # guarantee not Friday
+        timbot.friday_index_elem = -1
+
+        timbot.sc = FakeSlackClient(lambda: {"messages": [{"user": "me",
+                                                           "text":
+                                                           "@timbot where "
+                                                           "lunch no feast"
+                                                           }
+                                                          ]
+                                             })
+        with pytest.raises(Exception) as e:
+            timbot.run_timbot()
+        assert str(e.value) in ['pauls', 'asian plus', 'moes',
+                                'the 99', 'chilis']
+
+        timbot.sc = FakeSlackClient(lambda: {"messages": [{"user": "me",
+                                                           "text":
+                                             "@timbot where lunch"}]})
+        with pytest.raises(Exception) as e:
+            timbot.run_timbot()
+        assert str(e.value) in ['epicurean feast']
+
+        # make it Friday
+        timbot.friday_index_elem = datetime.datetime.today().weekday()
+
+        timbot.sc = FakeSlackClient(lambda: {"messages": [{"user": "me",
+                                                           "text":
+                                             "@timbot where lunch"}]})
+        with pytest.raises(Exception) as e:
+            timbot.run_timbot()
+        assert str(e.value) in ['pauls', 'asian plus', 'moes',
+                                'the 99', 'chilis']
+
+    patch("timbot.send_message")
+
+    def test_when_lunch(self):
+        self.init_vars()
+        timbot.send_message = lambda arg: (_ for _ in ()).throw(Exception(arg))
+
+        timbot.sc = FakeSlackClient(lambda: {"messages": [{"user": "me",
+                                                           "text":
+                                             "@timbot when lunch"}]})
+        with pytest.raises(Exception) as e:
+            timbot.run_timbot()
+        assert str(e.value) in [timbot.utc_to_est("15:30")]
+
+        timbot.sc = FakeSlackClient(lambda: {"messages": [{"user": "me",
+                                                           "text":
+                                             "@timbot lunch time"}]})
+        with pytest.raises(Exception) as e:
+            timbot.run_timbot()
+        assert str(e.value) in [timbot.utc_to_est("15:30")]
+
+    patch("timbot.send_message")
+
+    def test_what_lunch(self):
+        self.init_vars()
+        timbot.send_message = lambda arg: (_ for _ in ()).throw(Exception(arg))
+
+        # guarantee not Friday
+        timbot.friday_index_elem = -1
+
+        timbot.sc = FakeSlackClient(lambda: {"messages": [{"user": "me",
+                                                           "text":
+                                             "@timbot what lunch"}]})
+        with pytest.raises(Exception) as e:
+            timbot.run_timbot()
+        assert str(e.value) in ['may I suggest the chicken sandwich']
+
+        timbot.sc = FakeSlackClient(lambda: {"messages": [{"user": "me",
+                                                           "text":
+                                             "@timbot what eat"}]})
+        with pytest.raises(Exception) as e:
+            timbot.run_timbot()
+        assert str(e.value) in ['may I suggest the chicken sandwich']
+
+        # make it Friday
+        timbot.friday_index_elem = datetime.datetime.today().weekday()
+
+        timbot.sc = FakeSlackClient(lambda: {"messages": [{"user": "me",
+                                                           "text":
+                                             "@timbot what lunch"}]})
+        with pytest.raises(Exception) as e:
+            timbot.run_timbot()
+        assert str(e.value) in ['Its friday enjoy a meal out. '
+                                'Maybe some french toast at pauls?']
+
+        timbot.sc = FakeSlackClient(lambda: {"messages": [{"user": "me",
+                                                           "text":
+                                             "@timbot what eat"}]})
+        with pytest.raises(Exception) as e:
+            timbot.run_timbot()
+        assert str(e.value) in ['Its friday enjoy a meal out. Maybe some '
+                                'french toast at pauls?']
+
+    patch("timbot.db.increment_webopoly_wins")
+    patch("timbot.send_message")
+
+    def test_increment_webopoly_wins(self):
+        self.init_vars()
+        timbot.conn = ""
+
+        def iww_func(_, name):
+            (_ for _ in ()).throw(Exception(name))
+        timbot.db.increment_webopoly_wins = iww_func
+        timbot.send_message = lambda arg: (_ for _ in ()).throw(Exception(arg))
+
+        timbot.sc = FakeSlackClient(lambda: {"messages": [{"user": "me",
+                                                           "text":
+                                                           "@timbot increment"
+                                                           " webopoly "
+                                             "win Jeff"}]})
+        with pytest.raises(Exception) as e:
+            timbot.run_timbot()
+        assert str(e.value) in ["Couldn't do it cause jeff"]
+
+    patch("timbot.db.get_webopoly_standings")
+    patch("timbot.send_message")
+
+    def test_show_webopoly_standings(self):
+        self.init_vars()
+        timbot.conn = ""
+        standings = [["Webopoly-king", 75], ["Webopoly-prince", 54],
+                     ["Webopoly-knight", 37], ["Webopoly-peasant", 2]]
+        timbot.db.get_webopoly_standings = lambda _: standings
+        timbot.send_message = lambda arg: (_ for _ in ()).throw(Exception(arg))
+
+        timbot.sc = FakeSlackClient(lambda: {"messages": [{"user": "me",
+                                             "text": "@timbot show webopoly "
+                                                           "standings"}]})
+        with pytest.raises(Exception) as e:
+            timbot.run_timbot()
+        assert str(e.value) in ["Webopoly-king is the reigning champ with "
+                                "75 wins\n"
+                                "Webopoly-prince is next with 54 wins\n"
+                                "Webopoly-knight is next with 37 wins\n"
+                                "And in last is loser Webopoly-peasant with 2 "
+                                "wins"]
+
+    patch("timbot.send_message")
+
+    def test_help(self):
+        timbot.sc = FakeSlackClient(lambda: {"messages": [{"user": "me",
+                                             "text": "@timbot help me"}]})
+        self.init_vars()
+        timbot.send_message = lambda arg: (_ for _ in ()).throw(Exception(arg))
+        with pytest.raises(Exception) as e:
+            timbot.run_timbot()
+        assert str(e.value) in [timbot.help_text]
+
+    patch("timbot.send_message")
+
+    def test_pounding(self):
+        timbot.sc = FakeSlackClient(lambda: {"messages": [{"user": "me",
+                                             "text": "@timbot what now?"}]})
+        self.init_vars()
+        timbot.send_message = lambda arg: (_ for _ in ()).throw(Exception(arg))
+        with pytest.raises(Exception) as e:
+            timbot.run_timbot()
+        assert str(e.value) in ["keep pounding"]
+
+    patch("timbot.send_message")
+
+    def test_ideal_lunch_time(self, capsys):
+        timbot.sc = FakeSlackClient(lambda: {"nothing": []})
+        self.init_vars()
+        timbot.send_message = lambda arg: (_ for _ in ()).throw(Exception(arg))
+
+        # guarantee not weekend
+        timbot.saturday_index_elem = -1
+        timbot.sunday_index_elem = -1
+
+        # make it ideal lunch time
+        timbot.ideal_lunch_time = datetime.datetime.now().strftime('%H:%M')
+
+        with pytest.raises(Exception) as e:
+            timbot.run_timbot()
+        assert str(e.value) in ["IT IS THE IDEAL LUNCH TIME GO TO LUNCH"]
+
+        # make it not ideal lunch time
+        timbot.ideal_lunch_time = "fake time"
+
+        timbot.run_timbot()
+        captured = capsys.readouterr()
+        assert captured.out == "[DEBUG]: no logs in history, sleeping...\n"

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,15 @@
+[tox]
+skipsdist = True
+
+[testenv]
+basepython = python3
+usedevelop = True
+deps =
+  pytest
+  numpy
+  mysql.connector
+
+[testenv:test]
+description = "Timbot testing"
+commands =
+  pytest -vvv


### PR DESCRIPTION
Fixes #50 

Run by simply giving the command "tox" in the same directory as the tox.ini file

Only covers logic in choosing response to given messages.

TODO:
- [ ] Expand these tests to cover bad paths if applicable
- [ ] Document the existence of these tests
- [ ] Create separate testing framework for testing SQL queries
